### PR TITLE
VS Code extension MVP (.vsix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ Thumbs.db
 *.log
 *.tmp
 
+# VS Code extension packages
+*.vsix
+
 # By convention, ignore generated binaries
 kscr

--- a/docs/VSCodeExtension.md
+++ b/docs/VSCodeExtension.md
@@ -1,0 +1,196 @@
+# VS Code Extension (.vsix) Notes / Roadmap
+
+This document describes what we should implement for a VS Code extension for the `kscr` language (file extension: `.ks`), starting from a minimal MVP (syntax highlighting) and growing incrementally.
+
+## Goals
+
+- Make `.ks` pleasant to edit in VS Code.
+- Ship **syntax highlighting** as an installable `.vsix` first.
+- Keep the foundation (structure / scope names / packaging) friendly for future LSP integration (completion, go-to-definition, diagnostics).
+
+## Non-goals (for MVP)
+
+- Precise parser/AST-driven highlighting.
+- Formatting/linting/typechecking integration.
+- Semantic tokens that depend on import resolution / module boundaries.
+
+## Implementation approaches (decision: TextMate first)
+
+### A. TextMate Grammar (tmLanguage) + language-configuration (recommended)
+
+- Fastest path to a working MVP.
+- Minimal dependencies, easy to package.
+- “Good enough” highlighting with reasonable effort.
+
+MVP uses this approach.
+
+### B. Semantic Tokens (requires more infrastructure)
+
+- Enables high-precision highlighting based on binding/type/module resolution.
+- Requires calling into `kscr` analysis from VS Code (typically via an LSP server).
+
+Consider in the LSP phase.
+
+### C. Tree-sitter
+
+- High quality, but higher long-term maintenance and more complex build/distribution.
+
+Consider only if/when it becomes necessary.
+
+## What to implement for MVP
+
+### 1) Language ID and file association
+
+- Language id: e.g. `kscr`
+- File extension: `.ks`
+- File icon (optional)
+
+### 2) TextMate grammar (syntax highlighting)
+
+Keep the grammar aligned with:
+
+- Lexer implementation: [src/lexer.rs](src/lexer.rs)
+- Spec (BNF): [docs/LanguageBNF.md](docs/LanguageBNF.md)
+
+#### Minimum token categories
+
+- **Comments**
+  - Line comment: `-- ...` (until end of line)
+  - Block comment: `{- ... -}` (nestable in the lexer)
+  - Shebang: first line `#!...` (treated as a comment)
+- **Literals**
+  - String: `"..."`
+  - Char: `'a'` (and escapes, per the lexer)
+  - Numbers: integer / float
+  - Booleans: `True` / `False`
+- **Keywords** (at least those recognized by the lexer)
+  - `module`, `where`, `import`, `export`
+  - `let`, `in`, `case`, `of`, `do`, `if`, `then`, `else`
+  - `type`, `data`, `class`, `instance`
+  - `infix`, `infixl`, `infixr`
+  - Highlight-only extras (BNF mentions them; lexer may not yet): `deriving`, `qualified`, `as`
+- **Operators / punctuation** (grouped rather than exhaustively enumerated)
+  - `->`, `<-`, `=>`, `::`, `==`, `/=`, `<=`, `>=`, `&&`, `||`, `++`, `:`
+  - `\` (lambda)
+  - `` ` `` (backtick infix call)
+- **Identifiers (rough heuristic)**
+  - lower-case / `_` start: variable/function
+  - Upper-case start: type name / data constructor (Haskell-like)
+
+#### Scope naming (guidelines)
+
+TextMate scopes determine theme compatibility. Prefer common scope names:
+
+- Comments: `comment.line.double-dash.kscr`, `comment.block.kscr`
+- String: `string.quoted.double.kscr`
+- Char: `constant.character.kscr`
+- Numbers: `constant.numeric.kscr`
+- Booleans: `constant.language.boolean.kscr`
+- Control keywords: `keyword.control.kscr` (let/case/do/if, ...)
+- Declaration keywords: `keyword.declaration.kscr` (module/import/data/type/class/instance, ...)
+- Types/constructors: `entity.name.type.kscr`
+- Operators: `keyword.operator.kscr` / `punctuation.definition.operator.kscr`
+
+### 3) language-configuration.json
+
+Provide basic editor experience:
+
+- Comment toggles
+  - lineComment: `--`
+  - blockComment: `{-` / `-}`
+- Brackets
+  - `()`, `[]`, `{}`
+- autoClosingPairs / surroundingPairs
+  - `""`, `''`, `()`, `[]`, `{}`
+- indentationRules (optional)
+  - After `where`, `let`, `do`, `of` indentation usually increases; keep the rule lightweight.
+
+### 4) Packaging (.vsix)
+
+- Implement as a standard Node.js-based VS Code extension.
+- Package `.vsix` using `vsce`.
+
+Typical commands:
+
+- `npm ci`
+- `npm run compile` (only if you add TypeScript)
+- `npx --yes @vscode/vsce package`
+
+For MVP, the extension can be grammar-only (no `extension.ts`).
+
+## Node.js installation for packaging (no .devcontainer features)
+
+`@vscode/vsce` requires **Node.js 20+**. If the container image only has Debian’s Node 18 (or no Node at all), install Node 20 from the network.
+
+### Debian/Ubuntu (recommended: NodeSource)
+
+1) Remove existing Debian-provided Node/npm (optional but helps avoid conflicts):
+
+```bash
+sudo apt-get remove -y nodejs npm
+sudo apt-get autoremove -y
+```
+
+2) Add NodeSource repository for Node 20, then install:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+3) Verify:
+
+```bash
+node -v
+npm -v
+npx --version
+```
+
+### Alternative: nvm
+
+If you prefer not to touch system packages, you can use `nvm` to install Node 20 in your user environment.
+
+## Recommended directory structure
+
+If we keep this in the same repo, separate language implementation from editor tooling:
+
+- `editors/vscode/`
+  - `package.json`
+  - `language-configuration.json`
+  - `syntaxes/kscr.tmLanguage.json`
+  - `README.md`
+
+## Notes / gotchas (kscr-specific)
+
+- Fully correct nested block comments (`{- -}`) are hard to express in TextMate; MVP highlighting may approximate.
+- `.` is used for module qualification (`A.B`), so tokenization/visual split matters.
+- ``a `f` b`` uses backticks for infix calls; highlighting inside backticks improves readability.
+
+## Future work (post-MVP)
+
+Suggested priority order:
+
+1. Snippets
+   - `module ... where`
+   - `main = do ...`
+   - `case ... of`
+   - `data ... = ... deriving (...)`
+2. Formatter integration (after `kscr fmt` exists)
+   - VS Code runs external command on save
+3. LSP (primary goal)
+   - Implement `textDocument/definition`, `hover`, `diagnostics` via `kscr`
+   - Respect kscr module resolution (import base is the importing file’s directory)
+4. Semantic highlighting
+   - Colorize types/constructors/local bindings/top-level bindings
+
+## Acceptance criteria (Definition of Done for MVP)
+
+- Opening a `.ks` file activates the `kscr` language.
+- Comments/strings/numbers/keywords/types are highlighted reasonably.
+- `npx --yes @vscode/vsce package` produces a `.vsix` that installs and works in VS Code.
+
+## References
+
+- Keywords (source of truth): [src/lexer.rs](src/lexer.rs)
+- Comments / shebang: [docs/LanguageBNF.md](docs/LanguageBNF.md)
+- Operators / infix calls: [docs/LanguageBNF.md](docs/LanguageBNF.md)

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,5 @@
+.gitignore
+.vscode/**
+**/*.ts
+**/*.map
+node_modules/**

--- a/editors/vscode/LICENSE
+++ b/editors/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mako10k
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,27 @@
+# kscr VS Code extension (MVP)
+
+Minimal `kscr` language support for `.ks` files.
+
+## 機能
+
+- Syntax highlighting via TextMate grammar
+- Basic editor configuration (comments / brackets / quotes)
+
+## 開発・パッケージング
+
+Prerequisites: Node.js 20+ (required by `@vscode/vsce`)
+
+```bash
+cd editors/vscode
+npx --yes @vscode/vsce package
+```
+
+Install the generated `.vsix` in VS Code:
+
+- Command palette → `Extensions: Install from VSIX...`
+
+## 仕様の参照元
+
+- lexer: https://github.com/mako10k/kscr/blob/main/src/lexer.rs
+- BNF: https://github.com/mako10k/kscr/blob/main/docs/LanguageBNF.md
+- 設計メモ: https://github.com/mako10k/kscr/blob/main/docs/VSCodeExtension.md

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,25 @@
+{
+  "comments": {
+    "lineComment": "--",
+    "blockComment": ["{-", "-}"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ]
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "kscr-vscode",
+  "displayName": "kscr",
+  "description": "Syntax highlighting and basic editing support for kscr (.ks).",
+  "version": "0.0.1",
+  "publisher": "mako10k",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mako10k/kscr.git",
+    "directory": "editors/vscode"
+  },
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "kscr",
+        "aliases": [
+          "kscr",
+          "ks"
+        ],
+        "extensions": [
+          ".ks"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "kscr",
+        "scopeName": "source.kscr",
+        "path": "./syntaxes/kscr.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/vscode/syntaxes/kscr.tmLanguage.json
+++ b/editors/vscode/syntaxes/kscr.tmLanguage.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "kscr",
+  "scopeName": "source.kscr",
+  "patterns": [
+    { "include": "#shebang" },
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#chars" },
+    { "include": "#numbers" },
+    { "include": "#booleans" },
+    { "include": "#keywords" },
+    { "include": "#typesAndCtors" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "shebang": {
+      "patterns": [
+        {
+          "name": "comment.line.shebang.kscr",
+          "match": "\\A#!.*$"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-dash.kscr",
+          "match": "--.*$"
+        },
+        {
+          "name": "comment.block.kscr",
+          "begin": "\\{-(?!#)",
+          "end": "-\\}",
+          "patterns": [
+            {
+              "name": "comment.block.kscr",
+              "begin": "\\{-",
+              "end": "-\\}"
+            }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.kscr",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.kscr",
+              "match": "\\\\(n|r|t|\\\\|\"|')"
+            }
+          ]
+        }
+      ]
+    },
+    "chars": {
+      "patterns": [
+        {
+          "name": "constant.character.kscr",
+          "match": "'(?:[^\\\\'\\n]|\\\\.)'"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.kscr",
+          "match": "\\b[0-9]+\\.[0-9]+(?:[eE][+-]?[0-9]+)?\\b"
+        },
+        {
+          "name": "constant.numeric.integer.kscr",
+          "match": "\\b[0-9]+\\b"
+        }
+      ]
+    },
+    "booleans": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.kscr",
+          "match": "\\b(True|False)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.kscr",
+          "match": "\\b(let|in|case|of|do|if|then|else|where)\\b"
+        },
+        {
+          "name": "keyword.declaration.kscr",
+          "match": "\\b(module|import|export|type|data|class|instance|infixl|infixr|infix|deriving|qualified|as)\\b"
+        }
+      ]
+    },
+    "typesAndCtors": {
+      "patterns": [
+        {
+          "name": "entity.name.type.kscr",
+          "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.kscr",
+          "match": "(->|<-|=>|::|==|/=|<=|>=|&&|\\\\|\\|\\|\\+\\+|:)"
+        },
+        {
+          "name": "punctuation.definition.operator.backtick.kscr",
+          "match": "`"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a minimal grammar-only VS Code extension for kscr (.ks) and documents the roadmap.

What’s included:
- TextMate grammar + language configuration under editors/vscode/
- English documentation for the extension plan and packaging

Packaging notes:
- @vscode/vsce requires Node.js 20+ (see docs/VSCodeExtension.md for installation steps)

How to package:
- cd editors/vscode
- npx --yes @vscode/vsce package
