### PR TITLE
Fix duplicate class when importing module qualified + unqualified

### DIFF
--- a/src/cli_impl.rs
+++ b/src/cli_impl.rs
@@ -129,18 +129,16 @@ fn dispatch_cmd(cmd: &str, mut args: std::vec::IntoIter<String>) -> Result<()> {
             Ok(())
         }
         "repl" => repl(),
-        "--install-stdlib" | "install-stdlib" => {
-            match types::install_embedded_stdlib() {
-                Ok(p) => {
-                    println!("stdlib installed to: {}", p.display());
-                    Ok(())
-                }
-                Err(e) => Err(crate::error::Error::msg(format!(
-                    "failed to install embedded stdlib: {}",
-                    e
-                ))),
+        "--install-stdlib" | "install-stdlib" => match types::install_embedded_stdlib() {
+            Ok(p) => {
+                println!("stdlib installed to: {}", p.display());
+                Ok(())
             }
-        }
+            Err(e) => Err(crate::error::Error::msg(format!(
+                "failed to install embedded stdlib: {}",
+                e
+            ))),
+        },
         "llvm-ir" => crate::cli::cli_llvm_ir::cmd_llvm_ir(args),
         "compile" => crate::cli::cli_compile::cmd_compile(args),
         _ => Err(crate::error::Error::msg(format!("unknown command: {cmd}"))),

--- a/src/types.rs
+++ b/src/types.rs
@@ -7171,7 +7171,13 @@ fn import_qualified_items_for_decl(
     // NOTE: we must also qualify *types inside* these declarations (instance heads, method
     // signatures, superclass predicates) so that instance resolution matches the qualified type
     // constructors introduced by imports (e.g. `Prelude.Maybe`).
-    out.extend(qualify_class_instance_decls(module, qual, exports)?);
+    //
+    // If the same module is imported multiple times under different qualifiers (e.g.
+    // `import Prelude` and `import qualified Prelude as P`), we must not duplicate class/instance
+    // decls; they are global and would trip `desugar_typeclasses` with "duplicate class".
+    if qual == module.name.as_deref().unwrap_or("") {
+        out.extend(qualify_class_instance_decls(module, qual, exports)?);
+    }
     Ok(out)
 }
 

--- a/src/types/stdlib_cache.rs
+++ b/src/types/stdlib_cache.rs
@@ -1,11 +1,11 @@
 use crate::{ast, parser, Result};
+use dirs;
+use include_dir::{include_dir, Dir, DirEntry};
 use std::collections::HashMap;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
-use std::fs;
-use include_dir::{include_dir, Dir, DirEntry};
-use dirs;
 
 #[derive(Clone)]
 struct CachedAst {

--- a/tests/import_prelude_qualified_and_unqualified.ks
+++ b/tests/import_prelude_qualified_and_unqualified.ks
@@ -1,0 +1,7 @@
+module Main where
+  import Prelude
+  import qualified Prelude as P
+
+  main :: IO Unit
+  main = do
+    P.putStrLn "Imports qualified"


### PR DESCRIPTION
Fixes Issue #28.

When the same module is imported both unqualified and also as a qualified alias (e.g. `import Prelude` + `import qualified Prelude as P`), import-flattening used to duplicate `ClassDecl`/`InstanceDecl` under each qualifier, causing typechecking to fail with `duplicate class`.

This change only emits class/instance decls for the module's canonical qualifier, avoiding duplication while keeping qualified value/type refs working.

Note: Haskell *does* allow qualified class names in constraints/instance contexts (e.g. `M.C a => ...`). This PR does not change kscr’s surface syntax for constraints; it only fixes duplicate import flattening.

Repro added: `tests/import_prelude_qualified_and_unqualified.ks`
