### PR TITLE
Stage 2 prep: qualified class refs + ClassId

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,6 +10,16 @@ pub struct Module {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleId(pub u32);
 
+/// Internal typeclass identity.
+///
+/// Stage 2 prep: keep this unused for now; later we will replace `class: String` references
+/// in predicates/instances with `ClassId`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ClassId {
+    pub module: ModuleId,
+    pub name: String,
+}
+
 /// A name that can be either syntactic (unresolved) or resolved to a module.
 ///
 /// The `module_name` is kept for diagnostics and pretty-printing.

--- a/src/parser_impl.rs
+++ b/src/parser_impl.rs
@@ -804,7 +804,8 @@ fn parse_instance_decl(ts: &mut TokenStream) -> Result<ast::Item> {
         }
     }
 
-    let class = ts.expect_ident()?;
+    // Allow qualified class name in instance head: `instance M.C T where ...`.
+    let class = parse_maybe_qualified_ident(ts)?;
     let ty = parse_type_expr(ts, Stop::LineEnd, is_type_end)?;
     ts.expect(TokenKind::KwWhere)?;
     ts.consume_line_end();

--- a/src/parser_impl/type_expr.rs
+++ b/src/parser_impl/type_expr.rs
@@ -20,7 +20,7 @@ pub(crate) fn parse_predicate_in_root(ts: &mut TokenStream, stop: Stop) -> Resul
 }
 
 fn parse_predicate(ts: &mut TokenStream, stop: Stop) -> Result<ast::Predicate> {
-    let name = ts.expect_ident()?;
+    let name = parse_maybe_qualified_ident(ts)?;
     match name.as_str() {
         "Show" => Ok(ast::Predicate::Show(parse_type_expr(
             ts,

--- a/src/types.rs
+++ b/src/types.rs
@@ -6772,7 +6772,7 @@ fn desugar_qualified_predicate(p: ast::Predicate, env: &QualEnv) -> Result<ast::
         ast::Predicate::Eq(t) => ast::Predicate::Eq(desugar_qualified_type(t, env)?),
         ast::Predicate::EqRow(t) => ast::Predicate::EqRow(desugar_qualified_type(t, env)?),
         ast::Predicate::Class { class, ty } => ast::Predicate::Class {
-            class,
+            class: desugar_qualified_ref(&class, env)?,
             ty: desugar_qualified_type(ty, env)?,
         },
         ast::Predicate::Lacks { label, row } => ast::Predicate::Lacks {

--- a/tests/qualified_class_in_predicate_and_instance.ks
+++ b/tests/qualified_class_in_predicate_and_instance.ks
@@ -1,0 +1,13 @@
+-- Ensures qualified class refs are accepted in predicates and instance heads.
+
+module Main where
+
+import qualified Prelude as P
+
+-- predicate: allow `P.Show Integer`
+f : P.Show Integer => Integer
+f x = x
+
+-- instance head: allow `instance P.Show Integer where`
+instance P.Show Integer where
+  show x = "ok"


### PR DESCRIPTION
## Summary
- Stage 2 prep: add `ast::ClassId` (no behavior change yet).
- Allow qualified class references in constraints and instance heads:
  - predicates: `P.Show Integer => ...`
  - instance heads: `instance P.Show Integer where ...`
- Add regression test covering both forms.

## Why
Stage 2 will replace stringly-typed class references with `(ModuleId, ClassName)`.
Allowing qualified class names now makes the surface syntax closer to Haskell and unblocks later ID-based resolution.

## Changes
- `src/ast.rs`: introduce `ClassId { module: ModuleId, name: String }`.
- `src/parser_impl/type_expr.rs`: parse predicate class name via `parse_maybe_qualified_ident`.
- `src/parser_impl.rs`: allow `instance M.C ...` in instance head.
- `src/types.rs`: run qualifier validation on predicate class names via `desugar_qualified_ref`.
- `tests/qualified_class_in_predicate_and_instance.ks`: new test.

## Test
- `cargo test -q`
