### PR TITLE
Typeclass dict fallback policy + main typing

### DIFF
--- a/docs/TypeclassDictFallbackPolicy.md
+++ b/docs/TypeclassDictFallbackPolicy.md
@@ -1,0 +1,48 @@
+# Typeclass dictionary handling policy
+
+## Goal
+
+We allow *ambiguity* (insufficient information) to flow through the pipeline.
+We do **not** allow ad-hoc or heuristic fallback that *commits* to a concrete typeclass dictionary early.
+
+This is especially important for methods like `return :: a -> m a` where the dictionary cannot be chosen from argument types alone.
+
+## Definitions
+
+- **Ambiguity**: the compiler cannot choose a unique dictionary (instance) given the currently known types.
+  - This is OK to keep as constraints and resolve later (or report if still ambiguous at the end).
+- **Ad-hoc/heuristic commitment (NG)**: choosing a specific dictionary based on partial information such as:
+  - method name special-casing (e.g. branching on the string `"return"`),
+  - selecting an instance from argument types only when the method’s type does not determine the class parameter,
+  - any other "best guess" rule.
+
+## Allowed behavior
+
+- Keep the call polymorphic by producing an expression that *references a dictionary parameter* (i.e. defer selection).
+- Report ambiguity only at a phase where no further information can arrive (or in an explicit debug/failfast mode).
+
+## Disallowed behavior
+
+- Any method-name special casing in type inference / dict resolution paths.
+- Heuristics that pick a concrete instance early in order to continue.
+
+## Diagnostics policy
+
+- Default mode: do not hard-error on ambiguity during rewrite/typecheck of incomplete programs (needed for LSP and partial edits).
+- FailFast mode (opt-in): surface ambiguity sites loudly and fail when a dictionary must be chosen but cannot.
+  - Current knob: `KSCR_FAILFAST_METHOD_DICT=1`.
+
+## Work items (TODO)
+
+1. Remove any remaining method-name branching (e.g. `"return"`) from `src/types.rs`. ✅
+2. Audit dictionary resolution paths for early commitment:
+   - functions that return `Ok(Some(...))` / `Ok(None)` etc,
+   - ensure `Ok(None)` means "defer via dict parameter" and never means "pick a guess".
+3. Make ambiguity representation explicit:
+   - tag deferred dictionary sites with structured metadata for diagnostics (method name, location, required class, partial types).
+4. Fix letrec/SCC recursion case:
+   - ensure dictionaries available from expected types (annotations / surrounding context) are visible during rewrite,
+   - for methods whose class parameter is not determined by argument types (e.g. `return`/`pure`), prefer using the inferred application type to choose an instance (or defer).
+5. Add regression tests:
+   - `tests/repro_return_in_letrec_fail.ks` should typecheck when an expected `IO` context is available. ✅
+   - keep a test that verifies incomplete code used by LSP can still produce completions in default mode.

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -13,8 +13,6 @@ type Integer = crate::safe_bigint::Integer;
 
 // NOTE: IR data types are defined in `crates/kscr_ir` and re-exported here.
 
-
-
 /// Apply default optimization passes to an IR module.
 ///
 /// This applies a standard set of safe optimizations:

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -13,8 +13,7 @@ type Integer = crate::safe_bigint::Integer;
 
 // NOTE: IR data types are defined in `crates/kscr_ir` and re-exported here.
 
-/// The name of the IO Monad dictionary used to auto-apply to Closures in IO contexts.
-const IO_MONAD_DICT_NAME: &str = "__dict_Prelude.Monad.Monad_IO";
+
 
 /// Apply default optimization passes to an IR module.
 ///
@@ -692,7 +691,7 @@ pub fn run_main(module: &IrModule) -> Result<Value> {
     }
     let v = eval_var(&g, &std::collections::HashMap::new(), "main")?;
     let v = force_value(&g, v)?;
-    let v = auto_apply_io_monad_dict(&g, v)?;
+    let v = auto_apply_io_dict(&g, v)?;
 
     let Value::IoAction(action) = v else {
         return Err(Error::msg(format!(
@@ -742,30 +741,30 @@ fn value_type_name(v: &Value) -> &'static str {
     }
 }
 
-/// Auto-apply the IO Monad dictionary if the value is a Closure expecting one.
+/// Auto-apply a dictionary when a Closure expects one in an IO context.
 /// This handles do-notation that desugars to lambdas expecting dictionaries.
 ///
-/// The heuristic checks if the Closure has exactly one parameter that:
-/// - Starts with "__dict_" (convention for dictionary parameters)
-/// - Contains "Monad" (indicating it's a Monad dictionary)
+/// The heuristic checks if the Closure has exactly one parameter starting with
+/// "__dict_" and attempts to find a matching IO instance dictionary by appending
+/// "_IO" to the parameter name.
 ///
 /// While this relies on naming conventions, it matches the desugaring behavior
 /// of the typechecker/compiler, which generates these parameter names.
-fn auto_apply_io_monad_dict(g: &Globals, v: Value) -> Result<Value> {
+fn auto_apply_io_dict(g: &Globals, v: Value) -> Result<Value> {
     if let Value::Closure {
         params,
         body: _,
         env: _,
     } = &v
     {
-        if params.len() == 1
-            && params[0].starts_with("__dict_")
-            && params[0].contains("Monad")
-            && g.defs.contains_key(IO_MONAD_DICT_NAME)
-        {
-            let io_dict = eval_var(g, &std::collections::HashMap::new(), IO_MONAD_DICT_NAME)?;
-            let v = apply_one(g, v, io_dict)?;
-            return force_value(g, v);
+        if params.len() == 1 && params[0].starts_with("__dict_") {
+            // Try to find an IO instance by appending "_IO" to the class dictionary name.
+            let io_dict_name = format!("{}_IO", params[0]);
+            if g.defs.contains_key(&io_dict_name) {
+                let io_dict = eval_var(g, &std::collections::HashMap::new(), &io_dict_name)?;
+                let v = apply_one(g, v, io_dict)?;
+                return force_value(g, v);
+            }
         }
     }
     Ok(v)
@@ -1261,7 +1260,7 @@ fn run_io_bind_value(g: &Globals, action: IoAction, func: Value) -> Result<IoOut
     let func = force_value(g, func)?;
     let act = apply_one(g, func, v)?;
     let act = force_value(g, act)?;
-    let act = auto_apply_io_monad_dict(g, act)?;
+    let act = auto_apply_io_dict(g, act)?;
     let Value::IoAction(act) = act else {
         return Err(Error::msg(format!(
             "__ioBind: body did not evaluate to an IO action (got {})",
@@ -1293,7 +1292,7 @@ fn run_io_bind(
     env.insert(param, v);
     let act = eval_expr(g, &env, &body)?;
     let act = force_value(g, act)?;
-    let act = auto_apply_io_monad_dict(g, act)?;
+    let act = auto_apply_io_dict(g, act)?;
     let Value::IoAction(act) = act else {
         return Err(Error::msg(format!(
             "IoBind body did not evaluate to an IO action (got {})",
@@ -1315,7 +1314,7 @@ fn run_io_then(
     }
     let act = eval_expr(g, &env, &then_expr)?;
     let act = force_value(g, act)?;
-    let act = auto_apply_io_monad_dict(g, act)?;
+    let act = auto_apply_io_dict(g, act)?;
     let Value::IoAction(act) = act else {
         return Err(Error::msg(format!(
             "IoThen body did not evaluate to an IO action (got {})",
@@ -1494,7 +1493,7 @@ fn builtin_try(g: &Globals, arg: Value) -> Result<Value> {
 
 fn builtin_io_bind1(g: &Globals, act: Value, func: Value) -> Result<Value> {
     let act = force_value(g, act)?;
-    let act = auto_apply_io_monad_dict(g, act)?;
+    let act = auto_apply_io_dict(g, act)?;
     let Value::IoAction(act) = act else {
         return Err(Error::msg(format!(
             "__ioBind expects IO action (got {})",
@@ -1509,7 +1508,7 @@ fn builtin_io_bind1(g: &Globals, act: Value, func: Value) -> Result<Value> {
 
 fn builtin_io_then1(g: &Globals, first: Value, then_action: Value) -> Result<Value> {
     let first = force_value(g, first)?;
-    let first = auto_apply_io_monad_dict(g, first)?;
+    let first = auto_apply_io_dict(g, first)?;
     let Value::IoAction(first) = first else {
         return Err(Error::msg(format!(
             "__ioThen expects IO action (got {} for first argument)",
@@ -1517,7 +1516,7 @@ fn builtin_io_then1(g: &Globals, first: Value, then_action: Value) -> Result<Val
         )));
     };
     let then_action = force_value(g, then_action)?;
-    let then_action = auto_apply_io_monad_dict(g, then_action)?;
+    let then_action = auto_apply_io_dict(g, then_action)?;
     let Value::IoAction(then_action) = then_action else {
         return Err(Error::msg(format!(
             "__ioThen expects IO action (got {} for second argument)",

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -1017,8 +1017,9 @@ fn typecheck_main_must_be_io_unit() {
     let m_bad = crate::parser::parse_module("main = 1\n").unwrap();
     assert!(crate::types::typecheck(m_bad).is_err());
 
-    let m_bad2 = crate::parser::parse_module("main = IO 1\n").unwrap();
-    assert!(crate::types::typecheck(m_bad2).is_err());
+    // Haskell-like: main may return any `IO a`.
+    let m_ok2 = crate::parser::parse_module("main = IO 1\n").unwrap();
+    crate::types::typecheck(m_ok2).unwrap();
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -6487,12 +6487,13 @@ fn typecheck_internal_core_with_entry_path(
             merge_class_env(&mut class_env, stdlib_env)?;
         }
 
-        // If `Monad` is available, desugar `do`-notation into `(>>=)` / `(>>)`. This allows `do` to
-        // work for non-IO monads (via type classes).
-        if class_env
-            .class_params
-            .keys()
-            .any(|c| c.name == "Monad" || c.name.ends_with(".Monad"))
+        // If `>>=` and `>>` operators are available (typically from a Monad-like type class),
+        // desugar `do`-notation into those operators. This allows `do` to work for any monad
+        // (via type classes), not just IO.
+        // If these operators are not available, do-notation remains as ExprKind::Do and is
+        // lowered directly to IR IoBind/IoThen constructs (IO-only fallback).
+        if class_env.method_classes.contains_key(">>=")
+            && class_env.method_classes.contains_key(">>")
         {
             desugar_do_to_monad_ops_in_module(&mut module)?;
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -10230,18 +10230,129 @@ fn monad_syntactic_head(e: &ast::Expr) -> Option<String> {
 
 fn resolve_method_dict_expr(
     ctx: &ApplyRewriteCtx<'_>,
-    class: &str,
+    class_id: &ast::ClassId,
     mname: &str,
     args: &[ast::Expr],
 ) -> Result<Option<(ast::Expr, Option<String>)>> {
-    use ast::{Expr, ExprKind};
+    use ast::{Expr, ExprKind, Type};
 
+    fn unqualified_class_name(class: &str) -> &str {
+        class.rsplit('.').next().unwrap_or(class)
+    }
+
+    fn type_contains_var(ty: &Type, v: &str) -> bool {
+        match ty {
+            Type::Unit
+            | Type::Integer
+            | Type::Bool
+            | Type::Float64
+            | Type::Char
+            | Type::String
+            | Type::Hole(_) => false,
+            Type::Var(name) => name == v,
+            Type::List(t) => type_contains_var(t, v),
+            Type::Tuple(ts) => ts.iter().any(|t| type_contains_var(t, v)),
+            Type::Record(fields) => fields.iter().any(|(_, t)| type_contains_var(t, v)),
+            Type::RecordOpen(fields, rest) => {
+                fields.iter().any(|(_, t)| type_contains_var(t, v)) || type_contains_var(rest, v)
+            }
+            Type::App { head, args } => {
+                type_contains_var(head, v) || args.iter().any(|t| type_contains_var(t, v))
+            }
+            Type::Func(a, b) => type_contains_var(a, v) || type_contains_var(b, v),
+        }
+    }
+
+    fn method_class_param_determined_by_args(
+        class_env: &ClassEnv,
+        class_id: &ast::ClassId,
+        mname: &str,
+    ) -> bool {
+        let Some(param) = class_env.class_params.get(class_id) else {
+            return true;
+        };
+        let Some(qt) = class_env
+            .methods
+            .get(&(class_id.clone(), mname.to_string()))
+        else {
+            return true;
+        };
+
+        let mut cur = &qt.ty;
+        while let Type::Func(a, b) = cur {
+            if type_contains_var(a, param) {
+                return true;
+            }
+            cur = b;
+        }
+        false
+    }
+
+    let class = class_id.name.as_str();
+
+    // Prefer an in-scope dictionary param when available.
     let dict_var = format!("__dict_{class}");
+    let dict_var_unqual = format!("__dict_{}", unqualified_class_name(class));
     if ctx.dicts_in_scope.contains(&dict_var) {
         return Ok(Some((
             Expr::new(ctx.span, ExprKind::Var(dict_var.clone())),
             Some(dict_var),
         )));
+    }
+    if ctx.dicts_in_scope.contains(&dict_var_unqual) {
+        return Ok(Some((
+            Expr::new(ctx.span, ExprKind::Var(dict_var_unqual.clone())),
+            Some(dict_var_unqual),
+        )));
+    }
+
+    // Prefer a dictionary already fixed by surrounding context.
+    if let Some(d) = ctx
+        .known_dicts_in_scope
+        .get(class)
+        .or_else(|| ctx.known_dicts_in_scope.get(unqualified_class_name(class)))
+    {
+        let chosen_name_for_known = Some(d.clone());
+        return Ok(Some((
+            Expr::new(ctx.span, ExprKind::Var(d.clone())),
+            chosen_name_for_known,
+        )));
+    }
+
+    let determined_by_args = method_class_param_determined_by_args(ctx.class_env, class_id, mname);
+
+    // If the class parameter is not determined by argument types (e.g. `pure`, `return`),
+    // try to use the inferred type of the whole application to pick an instance.
+    if !determined_by_args {
+        let app_expr = Expr::new(
+            ctx.span,
+            ExprKind::Apply {
+                func: Box::new(Expr::new(ctx.span, ExprKind::Var(mname.to_string()))),
+                args: args.to_vec(),
+            },
+        );
+        if let Ok(app_ty) = infer_in_module_with_class_env(
+            ctx.module_snapshot,
+            ctx.class_env,
+            ctx.inferred,
+            app_expr,
+        ) {
+            if ftv_ty(&app_ty).is_empty() {
+                if let Ok(head) = instance_head_key_ty_for_class(class, &app_ty) {
+                    if let Some(d) = ctx.class_env.instances.get(&(class_id.clone(), head)) {
+                        let chosen_name_for_known = Some(d.clone());
+                        return Ok(Some((
+                            Expr::new(ctx.span, ExprKind::Var(d.clone())),
+                            chosen_name_for_known,
+                        )));
+                    }
+                    return Err(Error::msg_with_span(
+                        format!("no instance found for method call `{mname}`: {class} {app_ty}"),
+                        ctx.span,
+                    ));
+                }
+            }
+        }
     }
 
     let mut first_non_ground: Option<Ty> = None;
@@ -10249,72 +10360,55 @@ fn resolve_method_dict_expr(
     let mut dict_name: Option<String> = None;
 
     let is_monad = class == "Monad" || class.ends_with(".Monad");
-    if is_monad {
-        for a in args {
-            let Some(head) = monad_syntactic_head(a) else {
-                continue;
-            };
 
-            let Some(class_id) = ctx
-                .class_env
-                .class_params
-                .keys()
-                .find(|id| id.name == class)
-                .cloned()
-            else {
-                continue;
-            };
+    if determined_by_args {
+        if is_monad {
+            for a in args {
+                let Some(head) = monad_syntactic_head(a) else {
+                    continue;
+                };
 
-            let key = (class_id, head);
-            if let Some(d) = ctx.class_env.instances.get(&key) {
-                dict_name = Some(d.clone());
-                break;
+                let key = (class_id.clone(), head);
+                if let Some(d) = ctx.class_env.instances.get(&key) {
+                    dict_name = Some(d.clone());
+                    break;
+                }
             }
         }
-    }
 
-    if dict_name.is_none() {
-        for a in args {
-            let Ok(a_ty) = infer_in_module_with_class_env(
-                ctx.module_snapshot,
-                ctx.class_env,
-                ctx.inferred,
-                a.clone(),
-            ) else {
-                continue;
-            };
-
-            if !ftv_ty(&a_ty).is_empty() {
-                if first_non_ground.is_none() {
-                    first_non_ground = Some(a_ty.clone());
-                }
-                if !is_monad {
+        if dict_name.is_none() {
+            for a in args {
+                let Ok(a_ty) = infer_in_module_with_class_env(
+                    ctx.module_snapshot,
+                    ctx.class_env,
+                    ctx.inferred,
+                    a.clone(),
+                ) else {
                     continue;
+                };
+
+                if !ftv_ty(&a_ty).is_empty() {
+                    if first_non_ground.is_none() {
+                        first_non_ground = Some(a_ty.clone());
+                    }
+                    if !is_monad {
+                        continue;
+                    }
                 }
-            }
 
-            let Ok(head) = instance_head_key_ty_for_class(class, &a_ty) else {
-                continue;
-            };
+                let Ok(head) = instance_head_key_ty_for_class(class, &a_ty) else {
+                    continue;
+                };
 
-            let Some(class_id) = ctx
-                .class_env
-                .class_params
-                .keys()
-                .find(|id| id.name == class)
-                .cloned()
-            else {
-                continue;
-            };
+                let key = (class_id.clone(), head);
+                if let Some(d) = ctx.class_env.instances.get(&key) {
+                    dict_name = Some(d.clone());
+                    break;
+                }
 
-            let key = (class_id, head);
-            if let Some(d) = ctx.class_env.instances.get(&key) {
-                dict_name = Some(d.clone());
-                break;
-            }
-
-            if first_missing_instance.is_none() {
-                first_missing_instance = Some(a_ty);
+                if first_missing_instance.is_none() {
+                    first_missing_instance = Some(a_ty);
+                }
             }
         }
     }
@@ -10326,13 +10420,7 @@ fn resolve_method_dict_expr(
             chosen_name_for_known,
         )));
     }
-    if let Some(d) = ctx.known_dicts_in_scope.get(class) {
-        let chosen_name_for_known = Some(d.clone());
-        return Ok(Some((
-            Expr::new(ctx.span, ExprKind::Var(d.clone())),
-            chosen_name_for_known,
-        )));
-    }
+
     if let Some(d) = derive_dict_expr_from_candidates(
         ctx.span,
         ctx.class_env,
@@ -10343,15 +10431,37 @@ fn resolve_method_dict_expr(
         return Ok(Some((d, None)));
     }
 
-    if let Some(ty) = first_missing_instance {
+    // If we saw only concrete (ground) argument types and still couldn't find an instance,
+    // this is a real “missing instance” error.
+    // If we saw any non-ground arg type, treat it as ambiguity and defer (non-strict mode).
+    if determined_by_args && first_non_ground.is_none() {
+        if let Some(ty) = first_missing_instance {
+            return Err(Error::msg_with_span(
+                format!("no instance found for method call `{mname}`: {class} {ty}"),
+                ctx.span,
+            ));
+        }
+    }
+
+    // IMPORTANT: Dictionary choice failure means we don't have enough information at this
+    // rewrite stage. Historically we kept such calls polymorphic by producing a dict-lambda.
+    // This behaves like a fallback and can mask bugs, so allow opting into strict fail-fast.
+    let failfast = std::env::var("KSCR_FAILFAST_METHOD_DICT").ok().as_deref() == Some("1");
+    if failfast {
+        eprintln!(
+            "[KSCR_FAILFAST_METHOD_DICT] cannot choose dictionary for `{mname}` (class={class}) args_len={} span={:?}",
+            args.len(),
+            ctx.span
+        );
         return Err(Error::msg_with_span(
-            format!("no instance found for method call `{mname}`: {class} {ty}"),
+            format!(
+                "cannot choose dictionary for method call `{mname}`: {class} (insufficient information)"
+            ),
             ctx.span,
         ));
     }
 
-    // No in-scope dictionary and no ground type to pick an instance: keep it polymorphic.
-    // The caller will wrap this in a dict-lambda.
+    // Non-strict mode: keep it polymorphic (caller will wrap in a dict-lambda).
     Ok(None)
 }
 
@@ -10421,7 +10531,7 @@ fn rewrite_class_method_apply(
             };
 
             if let Some((dict_expr, chosen_name_for_known)) =
-                resolve_method_dict_expr(ctx, &class.name, mname, &args)?
+                resolve_method_dict_expr(ctx, class, mname, &args)?
             {
                 let mut known = ctx.known_dicts_in_scope.clone();
                 if let Some(chosen) = chosen_name_for_known.clone() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6517,12 +6517,27 @@ fn typecheck_internal_core_with_entry_path(
         };
 
         if let Some(main) = inferred.get("main") {
-            let expected = Ty::App {
+            // Haskell-like: accept any `IO a` as an entry point.
+            // If `main` is polymorphic (e.g. `forall m. Monad m => m Unit`), we accept it iff it
+            // can be instantiated to `IO a` with all constraints solved.
+            let mut cx = InferCtx::default();
+            let (cs, ty) = instantiate_qual(&mut cx, main);
+            let Ty::Var(a) = cx.fresh() else { unreachable!() };
+            let io_a = Ty::App {
                 head: Box::new(Ty::Con("IO".to_string())),
-                args: vec![Ty::Con("Unit".to_string())],
+                args: vec![Ty::Var(a)],
             };
-            if !main.vars.is_empty() || !main.constraints.is_empty() || main.ty != expected {
-                return Err(Error::msg("main must have type IO Unit"));
+            let subst = unify(ty, io_a)
+                .map_err(|_| Error::msg("main must have type IO _"))?;
+
+            let data_env = collect_data_env(&module);
+            let cs = simplify_constraints(
+                &data_env,
+                &class_env,
+                apply_constraints(&subst, cs),
+            )?;
+            if !cs.is_empty() {
+                return Err(Error::msg("main must have type IO _"));
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -9963,16 +9963,47 @@ impl<'a> RewriteClassMethodCallsCtx<'a> {
     }
 }
 
-fn instance_head_key_ty_for_class(class: &str, ty: &Ty) -> Result<String> {
+fn class_is_higher_kinded(class_env: &ClassEnv, class_id: &ast::ClassId) -> bool {
+    use ast::Type;
+
+    fn has_app_head_var(ty: &Type, v: &str) -> bool {
+        match ty {
+            Type::App { head, args } => {
+                matches!(head.as_ref(), Type::Var(name) if name == v)
+                    || has_app_head_var(head, v)
+                    || args.iter().any(|a| has_app_head_var(a, v))
+            }
+            Type::List(t) => has_app_head_var(t, v),
+            Type::Tuple(ts) => ts.iter().any(|t| has_app_head_var(t, v)),
+            Type::Record(fields) => fields.iter().any(|(_, t)| has_app_head_var(t, v)),
+            Type::RecordOpen(fields, rest) => {
+                fields.iter().any(|(_, t)| has_app_head_var(t, v)) || has_app_head_var(rest, v)
+            }
+            Type::Func(a, b) => has_app_head_var(a, v) || has_app_head_var(b, v),
+            _ => false,
+        }
+    }
+
+    let Some(param) = class_env.class_params.get(class_id) else {
+        return false;
+    };
+
+    for ((cid, _), qt) in &class_env.methods {
+        if cid == class_id && has_app_head_var(&qt.ty, param) {
+            return true;
+        }
+    }
+    false
+}
+
+fn instance_head_key_ty_for_class(
+    class_env: &ClassEnv,
+    class_id: &ast::ClassId,
+    ty: &Ty,
+) -> Result<String> {
     // MVP: higher-kinded classes select instances by the type constructor head.
     // e.g. `Functor` instance is declared for `Maybe`, but call sites see `Maybe a`.
-    let is_hk_class = class == "Monad"
-        || class.ends_with(".Monad")
-        || class == "Applicative"
-        || class.ends_with(".Applicative")
-        || class == "Functor"
-        || class.ends_with(".Functor");
-    if is_hk_class {
+    if class_is_higher_kinded(class_env, class_id) {
         return Ok(match ty {
             Ty::Con(name) => name.clone(),
             Ty::App { head, .. } => match head.as_ref() {
@@ -10233,16 +10264,6 @@ fn rewrite_class_method_lambda(
     ))
 }
 
-fn monad_syntactic_head(e: &ast::Expr) -> Option<String> {
-    match &e.kind {
-        ast::ExprKind::Ctor(n) => Some(n.qualified_text()),
-        ast::ExprKind::Apply { func, .. } => match &func.kind {
-            ast::ExprKind::Ctor(n) => Some(n.qualified_text()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
 
 fn resolve_method_dict_expr(
     ctx: &ApplyRewriteCtx<'_>,
@@ -10354,7 +10375,7 @@ fn resolve_method_dict_expr(
             app_expr,
         ) {
             if ftv_ty(&app_ty).is_empty() {
-                if let Ok(head) = instance_head_key_ty_for_class(class, &app_ty) {
+                if let Ok(head) = instance_head_key_ty_for_class(ctx.class_env, class_id, &app_ty) {
                     if let Some(d) = ctx.class_env.instances.get(&(class_id.clone(), head)) {
                         let chosen_name_for_known = Some(d.clone());
                         return Ok(Some((
@@ -10375,56 +10396,39 @@ fn resolve_method_dict_expr(
     let mut first_missing_instance: Option<Ty> = None;
     let mut dict_name: Option<String> = None;
 
-    let is_monad = class == "Monad" || class.ends_with(".Monad");
+    let hk_class = class_is_higher_kinded(ctx.class_env, class_id);
 
     if determined_by_args {
-        if is_monad {
-            for a in args {
-                let Some(head) = monad_syntactic_head(a) else {
-                    continue;
-                };
+        for a in args {
+            let Ok(a_ty) = infer_in_module_with_class_env(
+                ctx.module_snapshot,
+                ctx.class_env,
+                ctx.inferred,
+                a.clone(),
+            ) else {
+                continue;
+            };
 
-                let key = (class_id.clone(), head);
-                if let Some(d) = ctx.class_env.instances.get(&key) {
-                    dict_name = Some(d.clone());
-                    break;
+            // For first-order classes, instance selection needs a ground type key.
+            if !hk_class && !ftv_ty(&a_ty).is_empty() {
+                if first_non_ground.is_none() {
+                    first_non_ground = Some(a_ty.clone());
                 }
+                continue;
             }
-        }
 
-        if dict_name.is_none() {
-            for a in args {
-                let Ok(a_ty) = infer_in_module_with_class_env(
-                    ctx.module_snapshot,
-                    ctx.class_env,
-                    ctx.inferred,
-                    a.clone(),
-                ) else {
-                    continue;
-                };
+            let Ok(head) = instance_head_key_ty_for_class(ctx.class_env, class_id, &a_ty) else {
+                continue;
+            };
 
-                if !ftv_ty(&a_ty).is_empty() {
-                    if first_non_ground.is_none() {
-                        first_non_ground = Some(a_ty.clone());
-                    }
-                    if !is_monad {
-                        continue;
-                    }
-                }
+            let key = (class_id.clone(), head);
+            if let Some(d) = ctx.class_env.instances.get(&key) {
+                dict_name = Some(d.clone());
+                break;
+            }
 
-                let Ok(head) = instance_head_key_ty_for_class(class, &a_ty) else {
-                    continue;
-                };
-
-                let key = (class_id.clone(), head);
-                if let Some(d) = ctx.class_env.instances.get(&key) {
-                    dict_name = Some(d.clone());
-                    break;
-                }
-
-                if first_missing_instance.is_none() {
-                    first_missing_instance = Some(a_ty);
-                }
+            if first_missing_instance.is_none() {
+                first_missing_instance = Some(a_ty);
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6523,20 +6523,17 @@ fn typecheck_internal_core_with_entry_path(
             // can be instantiated to `IO a` with all constraints solved.
             let mut cx = InferCtx::default();
             let (cs, ty) = instantiate_qual(&mut cx, main);
-            let Ty::Var(a) = cx.fresh() else { unreachable!() };
+            let Ty::Var(a) = cx.fresh() else {
+                unreachable!()
+            };
             let io_a = Ty::App {
                 head: Box::new(Ty::Con("IO".to_string())),
                 args: vec![Ty::Var(a)],
             };
-            let subst = unify(ty, io_a)
-                .map_err(|_| Error::msg("main must have type IO _"))?;
+            let subst = unify(ty, io_a).map_err(|_| Error::msg("main must have type IO _"))?;
 
             let data_env = collect_data_env(&module);
-            let cs = simplify_constraints(
-                &data_env,
-                &class_env,
-                apply_constraints(&subst, cs),
-            )?;
+            let cs = simplify_constraints(&data_env, &class_env, apply_constraints(&subst, cs))?;
             if !cs.is_empty() {
                 return Err(Error::msg("main must have type IO _"));
             }
@@ -10263,7 +10260,6 @@ fn rewrite_class_method_lambda(
         },
     ))
 }
-
 
 fn resolve_method_dict_expr(
     ctx: &ApplyRewriteCtx<'_>,

--- a/tests/ambiguous_main.ks
+++ b/tests/ambiguous_main.ks
@@ -1,0 +1,2 @@
+module Main where
+  main = return ()

--- a/tests/repro_bind_return_unit_only.ks
+++ b/tests/repro_bind_return_unit_only.ks
@@ -1,0 +1,6 @@
+module Main where
+  import Prelude
+
+  main = do
+    u <- return ()
+    putStrLn "ok"

--- a/tests/repro_poly_in_recursion.ks
+++ b/tests/repro_poly_in_recursion.ks
@@ -1,0 +1,11 @@
+module Main where
+  import Prelude
+
+  printLines [] = return ()
+  printLines (x:xt) = do
+    putStrLn x
+    printLines xt
+
+  -- Use it at a concrete type.
+  main = do
+    printLines ["a", "b"]

--- a/tests/repro_poly_in_recursion2.ks
+++ b/tests/repro_poly_in_recursion2.ks
@@ -1,0 +1,11 @@
+module Main where
+  import Prelude
+
+  printLines [] = getLine
+  printLines (x:xt) = do
+    putStrLn x
+    printLines xt
+
+  main = do
+    _ <- printLines ["a", "b"]
+    putStrLn "done"

--- a/tests/repro_return_in_letrec_annot.ks
+++ b/tests/repro_return_in_letrec_annot.ks
@@ -1,0 +1,11 @@
+module Main where
+  import Prelude
+
+  f :: [String] -> IO Unit
+  f [] = return ()
+  f (x:xs) = do
+    putStrLn x
+    f xs
+
+  main = do
+    f ["a"]

--- a/tests/repro_return_in_letrec_fail.ks
+++ b/tests/repro_return_in_letrec_fail.ks
@@ -1,0 +1,10 @@
+module Main where
+  import Prelude
+
+  f [] = return ()
+  f (x:xs) = do
+    putStrLn x
+    f xs
+
+  main = do
+    f ["a"]

--- a/tests/repro_return_only.ks
+++ b/tests/repro_return_only.ks
@@ -1,0 +1,7 @@
+module Main where
+  import Prelude
+
+  x = return ()
+
+  main = do
+    putStrLn "ok"

--- a/tests/repro_return_unit.ks
+++ b/tests/repro_return_unit.ks
@@ -1,0 +1,6 @@
+module Main where
+  import Prelude
+
+  main = do
+    _ <- return ()
+    putStrLn "ok"

--- a/tests/repro_return_unit2.ks
+++ b/tests/repro_return_unit2.ks
@@ -1,0 +1,6 @@
+module Main where
+  import Prelude
+
+  main = do
+    _ <- return ()
+    putStrLn "ok"


### PR DESCRIPTION
Implements docs/TypeclassDictFallbackPolicy.md.

- Remove heuristic dict commitment for class methods (e.g. return/pure-like) and defer on ambiguity (FailFast supported)
- Relax main entrypoint typing (accept IO a if constraints resolve)
- Reduce name-based Monad special-casing (types/ir)
- Add regression .ks repro cases

Verification:
- cargo test -q
- cargo run --bin kscr --all-features run tests/ambiguous_main.ks
