### PR TITLE
Implement PR#65 follow-ups: trailing comma & T() syntax error

### DIFF
--- a/src/parser_impl.rs
+++ b/src/parser_impl.rs
@@ -1034,6 +1034,11 @@ fn parse_export_spec(ts: &mut TokenStream) -> Result<ast::ExportSpec> {
 
     ts.bump();
 
+    // Issue #68: Reject T() (empty constructor list) following Haskell semantics
+    if matches!(ts.peek_kind(), Some(TokenKind::RParen)) {
+        return Err(ts.err_here("empty constructor list T() is not allowed; use T for type-only export or T(..) for all constructors"));
+    }
+
     let spec = if matches!(ts.peek_kind(), Some(TokenKind::Dot)) {
         ts.expect(TokenKind::Dot)?;
         ts.expect(TokenKind::Dot)?;
@@ -1054,6 +1059,10 @@ fn parse_export_spec(ts: &mut TokenStream) -> Result<ast::ExportSpec> {
         ctors.push(parse_ctor_name(ts)?);
         while matches!(ts.peek_kind(), Some(TokenKind::Comma)) {
             ts.bump();
+            // Issue #67: Allow trailing comma in constructor list
+            if matches!(ts.peek_kind(), Some(TokenKind::RParen)) {
+                break;
+            }
             ctors.push(parse_ctor_name(ts)?);
         }
         ts.expect(TokenKind::RParen)?;

--- a/tests/module_export_list.rs
+++ b/tests/module_export_list.rs
@@ -149,3 +149,94 @@ module Foo () where
     let specs = module.export_specs.unwrap();
     assert_eq!(specs.len(), 0);
 }
+
+// Issue #67: Allow trailing comma in constructor list
+#[test]
+fn test_module_export_type_with_trailing_comma_in_ctor_list() {
+    let src = r#"
+module Foo (MyType(A, B,)) where
+    data MyType = A | B | C
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_some());
+
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 1);
+
+    match &specs[0] {
+        kscr::ast::ExportSpec::Type { name, ctors } => {
+            assert_eq!(name, "MyType");
+            match ctors {
+                kscr::ast::ExportCtors::Some(names) => {
+                    assert_eq!(names.len(), 2);
+                    assert_eq!(names[0], "A");
+                    assert_eq!(names[1], "B");
+                }
+                _ => panic!("Expected Some ctors"),
+            }
+        }
+        _ => panic!("Expected Type export spec"),
+    }
+}
+
+// Issue #68: T() should be a syntax error
+#[test]
+fn test_module_export_empty_ctor_list_error() {
+    let src = r#"
+module Foo (MyType()) where
+    data MyType = A | B
+"#;
+    let result = parser_impl::parse_module(src);
+    assert!(result.is_err(), "T() should be a syntax error");
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("empty constructor list"),
+        "Error should mention empty constructor list, got: {}",
+        err
+    );
+}
+
+// Verify that T (type-only) still works
+#[test]
+fn test_module_export_type_only() {
+    let src = r#"
+module Foo (MyType) where
+    data MyType = A | B
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 1);
+
+    match &specs[0] {
+        kscr::ast::ExportSpec::Name(name) => {
+            assert_eq!(name, "MyType");
+        }
+        _ => panic!("Expected Name export spec"),
+    }
+}
+
+// Verify that T(..) (all constructors) still works
+#[test]
+fn test_module_export_all_ctors_still_works() {
+    let src = r#"
+module Foo (MyType(..)) where
+    data MyType = A | B
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 1);
+
+    match &specs[0] {
+        kscr::ast::ExportSpec::Type { name, ctors } => {
+            assert_eq!(name, "MyType");
+            assert!(matches!(ctors, kscr::ast::ExportCtors::All));
+        }
+        _ => panic!("Expected Type export spec"),
+    }
+}


### PR DESCRIPTION
This PR implements follow-up improvements to PR#65 as requested in issues #67 and #68.

## Changes

### Issue #67: Allow trailing comma in constructor list export specs
- **Support**: `MyType(A, B,)` in addition to `MyType(A, B)`
- **Implementation**: Modified the constructor list parsing loop in `parse_export_spec()` to check for `)` after consuming a comma, allowing an optional trailing comma
- **Test**: Added `test_module_export_type_with_trailing_comma_in_ctor_list()`

### Issue #68: Make `T()` a syntax error
- **Reject**: `T()` (empty constructor list) following Haskell 2010 semantics
- **Keep working**: `T` (type-only export) and `T(..)` (all constructors)
- **Implementation**: Added explicit check immediately after opening `(` to detect and reject empty constructor lists with a clear error message
- **Tests**: Added:
  - `test_module_export_empty_ctor_list_error()` - verifies `T()` is rejected
  - `test_module_export_type_only()` - verifies `T` still works
  - `test_module_export_all_ctors_still_works()` - verifies `T(..)` still works

## Haskell Compatibility

This PR aligns with Haskell 2010 semantics where:
- `T()` is explicitly disallowed (meaningless and confusing)
- `T` exports the type constructor only
- `T(..)` exports the type and all its data constructors
- Trailing commas are permitted for consistency with other comma-separated lists

## Testing

All tests pass:
- ✅ New tests for trailing comma support
- ✅ New tests for `T()` rejection
- ✅ Existing tests remain green
- ✅ `cargo clippy -- -D warnings` passes

## Files Changed

- `src/parser_impl.rs`: Modified `parse_export_spec()` function
- `tests/module_export_list.rs`: Added 4 new test cases

Closes #67
Closes #68
