### PR TITLE
feat: Accept Haskell-compatible newlines before 'where' in module headers

### DIFF
--- a/src/parser_impl.rs
+++ b/src/parser_impl.rs
@@ -310,6 +310,8 @@ fn parse_module_decl(ts: &mut TokenStream) -> Result<ast::Module> {
         None
     };
 
+    // Issue #70: Accept Haskell-compatible newlines/layout around `where`
+    skip_layout_tokens(ts);
     ts.expect(TokenKind::KwWhere)?;
     ts.consume_line_end();
     ts.skip_newlines();

--- a/tests/module_export_list.rs
+++ b/tests/module_export_list.rs
@@ -240,3 +240,96 @@ module Foo (MyType(..)) where
         _ => panic!("Expected Type export spec"),
     }
 }
+
+// Issue #70: Haskell-compatible newline/layout around `where` in module header
+#[test]
+fn test_module_export_list_newline_before_where() {
+    let src = r#"
+module Foo (x, y)
+where
+    x = 1
+    y = 2
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_some());
+
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 2);
+}
+
+#[test]
+fn test_module_export_list_newline_and_indent_before_where() {
+    let src = r#"
+module Foo (x, y, z)
+  where
+    x = 1
+    y = 2
+    z = 3
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_some());
+
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 3);
+}
+
+#[test]
+fn test_module_export_list_multiple_newlines_before_where() {
+    let src = r#"
+module Foo (x, y)
+
+
+where
+    x = 1
+    y = 2
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_some());
+
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 2);
+}
+
+#[test]
+fn test_module_without_export_list_newline_before_where() {
+    // Also test case without export list
+    let src = r#"
+module Foo
+where
+    x = 1
+    y = 2
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_none());
+}
+
+#[test]
+fn test_module_multiline_export_list_with_newline_before_where() {
+    // Combined: multiline export list + newline before where
+    let src = r#"
+module Foo (
+    x,
+    y,
+    z
+)
+where
+    x = 1
+    y = 2
+    z = 3
+"#;
+    let module = parser_impl::parse_module(src).unwrap();
+
+    assert_eq!(module.name, Some("Foo".to_string()));
+    assert!(module.export_specs.is_some());
+
+    let specs = module.export_specs.unwrap();
+    assert_eq!(specs.len(), 3);
+}


### PR DESCRIPTION
## Summary

Implements issue #70: Accept Haskell-compatible newlines/layout around `where` in module header export lists.

## Changes

### Parser Implementation
- Modified `parse_module_decl()` in `src/parser_impl.rs` to call `skip_layout_tokens()` before expecting the `where` keyword
- This allows newlines and indentation between the closing `)` of an export list and the `where` keyword

### Test Coverage
Added 5 comprehensive test cases in `tests/module_export_list.rs`:
1. **Simple newline before `where`**: `module Foo (x, y)\nwhere`
2. **Newline with indentation**: `module Foo (x, y, z)\n  where`
3. **Multiple newlines**: `module Foo (x, y)\n\n\nwhere`
4. **Without export list**: `module Foo\nwhere`
5. **Combined multiline export + newline**: `module Foo (\n    x,\n    y\n)\nwhere`

## Validation

✅ All existing tests pass  
✅ All new tests pass  
✅ `cargo clippy -- -D warnings` passes with no warnings  
✅ No breaking changes

## Backward Compatibility

This change is 100% backward compatible. All existing module declarations continue to work exactly as before. The parser now *additionally* accepts Haskell-style newlines before `where`, making the syntax more flexible and closer to Haskell.

## Examples

Before (still works):
```haskell
module Foo (x, y) where
    x = 1
```

Now also supported (Haskell-compatible):
```haskell
module Foo (x, y)
where
    x = 1
```

```haskell
module Foo (
    x,
    y,
    z
)
where
    x = 1
```

Closes #70
