### PR TITLE
feat(parser): support infix type operators in instance heads

### DIFF
--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -227,6 +227,38 @@ instance C a => C (Maybe a) where
 }
 
 #[test]
+fn parser_instance_head_accepts_parenthesized_infix_type_operator() {
+    let src = r#"
+class Eq a where
+    eq :: a -> a -> Bool
+
+instance Eq (a :*: b) where
+"#;
+
+    let m = crate::parser::parse_module(src).unwrap();
+    let inst = m
+        .items
+        .iter()
+        .find_map(|it| match it {
+            crate::ast::Item::InstanceDecl(i) => Some(i),
+            _ => None,
+        })
+        .expect("expected instance decl");
+
+    assert_eq!(inst.class.name, "Eq");
+    assert_eq!(
+        inst.ty,
+        crate::ast::Type::App {
+            head: Box::new(crate::ast::Type::Var(":*:".to_string())),
+            args: vec![
+                crate::ast::Type::Var("a".to_string()),
+                crate::ast::Type::Var("b".to_string()),
+            ],
+        }
+    );
+}
+
+#[test]
 fn typecheck_rejects_bad_superclass_predicate_shape() {
     let src = r#"
 class Inc a where

--- a/src/parser_impl/type_expr.rs
+++ b/src/parser_impl/type_expr.rs
@@ -244,7 +244,19 @@ fn parse_type_atom(
             }
 
             let first = parse_type_expr(ts, stop, is_paren_type_end)?;
-            if matches!(ts.peek_kind(), Some(TokenKind::Comma)) {
+            if matches!(ts.peek_kind(), Some(TokenKind::Operator(_))) {
+                let mut lhs = first;
+                while let Some(TokenKind::Operator(op)) = ts.peek_kind().cloned() {
+                    ts.bump();
+                    let rhs = parse_type_expr(ts, stop, is_paren_infix_rhs_end)?;
+                    lhs = ast::Type::App {
+                        head: Box::new(ast::Type::Var(op)),
+                        args: vec![lhs, rhs],
+                    };
+                }
+                ts.expect(TokenKind::RParen)?;
+                Ok(lhs)
+            } else if matches!(ts.peek_kind(), Some(TokenKind::Comma)) {
                 let mut elems = vec![first];
                 while matches!(ts.peek_kind(), Some(TokenKind::Comma)) {
                     ts.bump();
@@ -328,6 +340,13 @@ fn is_bracket_type_end(kind: Option<&TokenKind>, _stop: Stop) -> bool {
 
 fn is_record_field_type_end(kind: Option<&TokenKind>, _stop: Stop) -> bool {
     matches!(kind, Some(TokenKind::Comma) | Some(TokenKind::RBrace))
+}
+
+fn is_paren_infix_rhs_end(kind: Option<&TokenKind>, _stop: Stop) -> bool {
+    matches!(
+        kind,
+        Some(TokenKind::Operator(_)) | Some(TokenKind::Comma) | Some(TokenKind::RParen)
+    )
 }
 
 pub(crate) fn parse_annot(ts: &mut TokenStream, expr: ast::Expr, stop: Stop) -> Result<ast::Expr> {


### PR DESCRIPTION
## Summary
- support parenthesized infix type operators in instance heads (e.g. `instance Eq (a :*: b) where ...`)
- keep parser change minimal in `type_expr` parsing
- add parser regression test for the new accepted form

## Validation
- `cargo fmt --all -- --check`
- `cargo test -q parser_instance_head_accepts_parenthesized_infix_type_operator`
- `cargo test -q`

Fixes #71
