### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 [lib]
@@ -45,4 +45,3 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"
-

--- a/crates/kscr_ir/Cargo.toml
+++ b/crates/kscr_ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr_ir"
-version = "0.3.9"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/kscr_llvm/Cargo.toml
+++ b/crates/kscr_llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr_llvm"
-version = "0.3.9"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/kscr_lsp/Cargo.toml
+++ b/crates/kscr_lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr_lsp"
-version = "0.3.9"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/crates/kscr_unsafe_bigint/Cargo.toml
+++ b/crates/kscr_unsafe_bigint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr_unsafe_bigint"
-version = "0.3.9"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/crates/kscr_unsafe_ffi/Cargo.toml
+++ b/crates/kscr_unsafe_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kscr_unsafe_ffi"
-version = "0.3.9"
+version = "0.5.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- bump `kscr` version to `0.5.0`
- align Rust workspace crate versions (`kscr_ir`, `kscr_llvm`, `kscr_lsp`, `kscr_unsafe_ffi`, `kscr_unsafe_bigint`) to `0.5.0`

## Validation
- `cargo check -q`
- `cargo test -q --test ksif_hash_rebuild -- --test-threads=1`
- `cargo test -q` (note: observed known flaky behavior in `ksif_hash_rebuild` under parallel run)

## Notes
- This is a minor release cut following merged changes in PRs #79-#82.
