### PR TITLE
refactor(parser): make parser_impl internal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ pub mod ksif;
 pub mod lexer;
 pub mod parser;
 
-// Build `src/parser_impl.rs` as a public module for testing.
+// Keep parser internals private; use `crate::parser` as the public API.
 #[path = "parser_impl.rs"]
-pub mod parser_impl;
+mod parser_impl;
 #[cfg(not(feature = "unsafe_bigint"))]
 mod safe_bigint;
 pub mod types;

--- a/tests/export_deprecated.rs
+++ b/tests/export_deprecated.rs
@@ -1,6 +1,6 @@
 // Test for deprecated export declaration warning
 
-use kscr::parser_impl;
+use kscr::parser;
 
 #[test]
 fn test_export_decl_deprecated_warning() {
@@ -14,7 +14,7 @@ export x, y
     // Capture stderr to verify the warning is emitted
     // Note: In practice, the warning goes to stderr via eprintln!
     // This test just ensures parsing still works
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     // Find the export declaration
     let has_export = module
@@ -36,7 +36,7 @@ foo = 42
 data Bar = Baz | Qux
 "#;
 
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     // Find the export item
     let export_item = module

--- a/tests/import_lists.rs
+++ b/tests/import_lists.rs
@@ -1,6 +1,6 @@
 // Test for Haskell-style import lists and hiding clauses
 
-use kscr::{ast, parser_impl};
+use kscr::{ast, parser};
 
 #[test]
 fn test_import_simple() {
@@ -9,7 +9,7 @@ module Main where
     import Foo
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -29,7 +29,7 @@ module Main where
     import Foo (x, y, z)
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -55,7 +55,7 @@ module Main where
     import Foo (x, (++), y)
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -80,7 +80,7 @@ module Main where
     import Foo hiding (x, y)
     main = z
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -105,7 +105,7 @@ module Main where
     import qualified Foo as F (x, y)
     main = F.x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -136,7 +136,7 @@ module Main where
     )
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -161,7 +161,7 @@ module Main where
     import Foo ()
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -183,7 +183,7 @@ module Main where
     import Foo hiding (x, y,)
     main = z
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -208,7 +208,7 @@ module Main where
     import Foo as F (x, y)
     main = x
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -236,7 +236,7 @@ module Main where
     import qualified Foo as F hiding (x)
     main = F.y
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -263,7 +263,7 @@ module Main where
     import Prelude (Maybe(..))
     main = Just 42
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -294,7 +294,7 @@ module Main where
     import Prelude (Either(Left, Right))
     main = Left 42
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,
@@ -332,7 +332,7 @@ module Main where
     import MyMod (foo, Bar(..), baz)
     main = foo
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     let import = match &module.items[0] {
         ast::Item::Import(id) => id,

--- a/tests/infix_dot_dollar_integration.rs
+++ b/tests/infix_dot_dollar_integration.rs
@@ -1,4 +1,4 @@
-use kscr::parser_impl::parse_module;
+use kscr::parser::parse_module;
 use std::process::Command;
 
 #[test]

--- a/tests/module_export_list.rs
+++ b/tests/module_export_list.rs
@@ -1,6 +1,6 @@
 // Test for Haskell-style module export lists
 
-use kscr::parser_impl;
+use kscr::parser;
 
 #[test]
 fn test_module_export_list_simple() {
@@ -10,7 +10,7 @@ module Foo (x, y) where
     y = 2
     z = 3
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -41,7 +41,7 @@ module Foo (
     y = 2
     z = 3
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -56,7 +56,7 @@ fn test_module_export_list_with_type_all_ctors() {
 module Foo (MyType(..)) where
     data MyType = A | B | C
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -79,7 +79,7 @@ fn test_module_export_list_with_type_some_ctors() {
 module Foo (MyType(A, B)) where
     data MyType = A | B | C
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -110,7 +110,7 @@ module Foo where
     x = 1
     y = 2
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_none());
@@ -126,7 +126,7 @@ module Foo (
     x = 1
     y = 2
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -141,7 +141,7 @@ fn test_module_empty_export_list() {
 module Foo () where
     x = 1
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -157,7 +157,7 @@ fn test_module_export_type_with_trailing_comma_in_ctor_list() {
 module Foo (MyType(A, B,)) where
     data MyType = A | B | C
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -188,7 +188,7 @@ fn test_module_export_empty_ctor_list_error() {
 module Foo (MyType()) where
     data MyType = A | B
 "#;
-    let result = parser_impl::parse_module(src);
+    let result = parser::parse_module(src);
     assert!(result.is_err(), "T() should be a syntax error");
     let err = result.unwrap_err();
     assert!(
@@ -205,7 +205,7 @@ fn test_module_export_type_only() {
 module Foo (MyType) where
     data MyType = A | B
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     let specs = module.export_specs.unwrap();
@@ -226,7 +226,7 @@ fn test_module_export_all_ctors_still_works() {
 module Foo (MyType(..)) where
     data MyType = A | B
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     let specs = module.export_specs.unwrap();
@@ -250,7 +250,7 @@ where
     x = 1
     y = 2
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -268,7 +268,7 @@ module Foo (x, y, z)
     y = 2
     z = 3
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -287,7 +287,7 @@ where
     x = 1
     y = 2
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());
@@ -305,7 +305,7 @@ where
     x = 1
     y = 2
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_none());
@@ -325,7 +325,7 @@ where
     y = 2
     z = 3
 "#;
-    let module = parser_impl::parse_module(src).unwrap();
+    let module = parser::parse_module(src).unwrap();
 
     assert_eq!(module.name, Some("Foo".to_string()));
     assert!(module.export_specs.is_some());


### PR DESCRIPTION
## Summary
- make `parser_impl` internal to reduce public API exposure
- keep `kscr::parser::parse_module` as the public parser API
- migrate integration tests from `kscr::parser_impl` to `kscr::parser`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -q --test infix_dot_dollar_integration --test module_export_list --test import_lists --test export_deprecated`
- `cargo test -q`

Fixes #69
