### PR TITLE
runtime: fix string traversal stack overflow

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -55,10 +55,8 @@ fn collect_ctor_aliases(module: &ast::Module) -> std::collections::HashMap<Strin
             continue;
         };
         match &b.expr.kind {
-            ast::ExprKind::Var(v) => {
-                if v.contains('.') {
-                    out.insert(name.clone(), v.clone());
-                }
+            ast::ExprKind::Var(v) if v.contains('.') => {
+                out.insert(name.clone(), v.clone());
             }
             ast::ExprKind::Ctor(v) => {
                 let v = v.qualified_text();
@@ -2756,7 +2754,7 @@ fn eq_list_like_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
     if a_elems.len() != b_elems.len() {
         return Ok(false);
     }
-    for (x, y) in a_elems.into_iter().zip(b_elems.into_iter()) {
+    for (x, y) in a_elems.into_iter().zip(b_elems) {
         if !eq_values(g, x, y)? {
             return Ok(false);
         }
@@ -2780,7 +2778,7 @@ fn eq_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
             if as_.len() != bs.len() {
                 return Ok(false);
             }
-            for (x, y) in as_.into_iter().zip(bs.into_iter()) {
+            for (x, y) in as_.into_iter().zip(bs) {
                 if !eq_values(g, x, y)? {
                     return Ok(false);
                 }
@@ -2832,7 +2830,7 @@ fn eq_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
                 if a_elems.len() != b_elems.len() {
                     return Ok(false);
                 }
-                for (x, y) in a_elems.into_iter().zip(b_elems.into_iter()) {
+                for (x, y) in a_elems.into_iter().zip(b_elems) {
                     if !eq_values(g, x, y)? {
                         return Ok(false);
                     }
@@ -2845,7 +2843,7 @@ fn eq_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
             if a_fields.len() != b_fields.len() {
                 return Ok(false);
             }
-            for ((ak, av), (bk, bv)) in a_fields.into_iter().zip(b_fields.into_iter()) {
+            for ((ak, av), (bk, bv)) in a_fields.into_iter().zip(b_fields) {
                 if ak != bk {
                     return Ok(false);
                 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -562,6 +562,8 @@ pub enum IoAction {
     },
 }
 
+type SharedEnv = std::rc::Rc<std::collections::HashMap<String, Value>>;
+
 #[derive(Debug, Clone)]
 pub enum Value {
     Unit,
@@ -654,7 +656,7 @@ pub enum Value {
     Closure {
         params: Vec<String>,
         body: Box<IrExpr>,
-        env: std::collections::HashMap<String, Value>,
+        env: SharedEnv,
     },
 }
 
@@ -824,7 +826,7 @@ fn try_get_default_dict(class_name: &str) -> Result<Value> {
                         func: Box::new(IrExpr::Var("show".to_string())),
                         args: vec![IrExpr::Var("x".to_string())],
                     }),
-                    env: std::collections::HashMap::new(),
+                    env: std::collections::HashMap::new().into(),
                 },
             )]))
         }
@@ -839,7 +841,7 @@ fn try_get_default_dict(class_name: &str) -> Result<Value> {
                             func: Box::new(IrExpr::Var("+".to_string())),
                             args: vec![IrExpr::Var("a".to_string()), IrExpr::Var("b".to_string())],
                         }),
-                        env: std::collections::HashMap::new(),
+                        env: std::collections::HashMap::new().into(),
                     },
                 ),
                 (
@@ -850,7 +852,7 @@ fn try_get_default_dict(class_name: &str) -> Result<Value> {
                             func: Box::new(IrExpr::Var("-".to_string())),
                             args: vec![IrExpr::Var("a".to_string()), IrExpr::Var("b".to_string())],
                         }),
-                        env: std::collections::HashMap::new(),
+                        env: std::collections::HashMap::new().into(),
                     },
                 ),
                 (
@@ -861,7 +863,7 @@ fn try_get_default_dict(class_name: &str) -> Result<Value> {
                             func: Box::new(IrExpr::Var("*".to_string())),
                             args: vec![IrExpr::Var("a".to_string()), IrExpr::Var("b".to_string())],
                         }),
-                        env: std::collections::HashMap::new(),
+                        env: std::collections::HashMap::new().into(),
                     },
                 ),
             ]))
@@ -876,7 +878,7 @@ fn try_get_default_dict(class_name: &str) -> Result<Value> {
                         func: Box::new(IrExpr::Var("==".to_string())),
                         args: vec![IrExpr::Var("a".to_string()), IrExpr::Var("b".to_string())],
                     }),
-                    env: std::collections::HashMap::new(),
+                    env: std::collections::HashMap::new().into(),
                 },
             )]))
         }
@@ -1163,7 +1165,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                     IrExpr::Var("second".to_string()),
                                 ],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                     (
@@ -1177,7 +1179,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                     IrExpr::Var("f".to_string()),
                                 ],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                     (
@@ -1188,7 +1190,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                 func: Box::new(IrExpr::Var("IO".to_string())),
                                 args: vec![IrExpr::Var("x".to_string())],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                 ]),
@@ -1216,7 +1218,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                     IrExpr::Var("second".to_string()),
                                 ],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                     (
@@ -1230,7 +1232,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                     IrExpr::Var("f".to_string()),
                                 ],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                     (
@@ -1241,7 +1243,7 @@ fn eval_builtin_var(g: &Globals, name: &str) -> Option<Value> {
                                 func: Box::new(IrExpr::Var("IO".to_string())),
                                 args: vec![IrExpr::Var("x".to_string())],
                             }),
-                            env: std::collections::HashMap::new(),
+                            env: std::collections::HashMap::new().into(),
                         },
                     ),
                 ]),
@@ -1315,7 +1317,7 @@ fn eval_expr(
         IrExpr::Lambda { params, body } => Value::Closure {
             params: params.clone(),
             body: body.clone(),
-            env: env.clone(),
+            env: std::rc::Rc::new(env.clone()),
         },
         IrExpr::Apply { func, args } => eval_apply(g, env, func, args)?,
         IrExpr::If {
@@ -1570,7 +1572,7 @@ fn run_io_get_args() -> Result<IoOutcome> {
 fn run_io_read_file(path: String) -> Result<IoOutcome> {
     let content = std::fs::read_to_string(&path)
         .map_err(|e| Error::msg(format!("readFile: failed to read '{}': {}", path, e)))?;
-    Ok(IoOutcome::Value(string_to_char_list(&content)))
+    Ok(IoOutcome::Value(Value::String(content)))
 }
 
 fn run_io_write_file(path: String, content: String) -> Result<IoOutcome> {
@@ -1973,7 +1975,7 @@ fn apply_closure(
     g: &Globals,
     params: Vec<String>,
     body: Box<IrExpr>,
-    env: std::collections::HashMap<String, Value>,
+    env: SharedEnv,
     arg: Value,
 ) -> Result<Value> {
     if params.is_empty() {
@@ -1981,13 +1983,17 @@ fn apply_closure(
     }
 
     let mut params = params;
-    let mut env = env;
+    let mut env = (*env).clone();
     let p = params.remove(0);
     env.insert(p, arg);
     if params.is_empty() {
         eval_expr(g, &env, &body)
     } else {
-        Ok(Value::Closure { params, body, env })
+        Ok(Value::Closure {
+            params,
+            body,
+            env: std::rc::Rc::new(env),
+        })
     }
 }
 
@@ -2150,8 +2156,34 @@ fn list_to_vec(g: &Globals, mut v: Value) -> Result<Vec<Value>> {
                 out.push(*h);
                 v = *t;
             }
+            Value::String(s) => {
+                out.extend(s.chars().map(Value::Char));
+                return Ok(out);
+            }
             other => return Err(Error::msg(format!("expected List, got {other:?}"))),
         }
+    }
+}
+
+fn string_uncons(s: String) -> Option<(Value, Value)> {
+    let mut chars = s.chars();
+    let head = chars.next()?;
+    let tail = chars.as_str();
+    let tail_value = if tail.is_empty() {
+        Value::ListNil
+    } else {
+        Value::String(tail.to_string())
+    };
+    Some((Value::Char(head), tail_value))
+}
+
+fn list_uncons(g: &Globals, v: Value) -> Result<Option<(Value, Value)>> {
+    let v = force_value(g, v)?;
+    match v {
+        Value::ListNil => Ok(None),
+        Value::ListCons(h, t) => Ok(Some((*h, *t))),
+        Value::String(s) => Ok(string_uncons(s)),
+        _ => Ok(None),
     }
 }
 
@@ -2626,9 +2658,10 @@ fn show_value_str(g: &Globals, v: Value) -> Result<String> {
         Value::Char(c) => quote_char(c),
         Value::Unit => "()".to_string(),
         Value::Tuple(vs) => {
-            let mut parts = Vec::new();
+            let mut parts: Vec<String> = Vec::new();
             for v in vs {
-                parts.push(show_value_str(g, v)?);
+                let v_forced = force_value(g, v)?;
+                parts.push(show_value_str(g, v_forced)?);
             }
             format!("({})", parts.join(", "))
         }
@@ -2717,6 +2750,20 @@ fn show_with_dict(g: &Globals, builtin_dict: Value, dict: Value, a: Value) -> Re
     apply_one(g, f, a)
 }
 
+fn eq_list_like_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
+    let a_elems = list_to_vec(g, a)?;
+    let b_elems = list_to_vec(g, b)?;
+    if a_elems.len() != b_elems.len() {
+        return Ok(false);
+    }
+    for (x, y) in a_elems.into_iter().zip(b_elems.into_iter()) {
+        if !eq_values(g, x, y)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn eq_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
     let a = force_and_auto_apply(g, a)?;
     let b = force_and_auto_apply(g, b)?;
@@ -2746,6 +2793,10 @@ fn eq_values(g: &Globals, a: Value, b: Value) -> Result<bool> {
         (Value::ListCons(a_hd, a_tl), Value::ListCons(b_hd, b_tl)) => {
             eq_values(g, *a_hd, *b_hd)? && eq_values(g, *a_tl, *b_tl)?
         }
+        (a @ Value::String(_), b @ Value::ListNil)
+        | (a @ Value::String(_), b @ Value::ListCons(_, _))
+        | (a @ Value::ListNil, b @ Value::String(_))
+        | (a @ Value::ListCons(_, _), b @ Value::String(_)) => eq_list_like_values(g, a, b)?,
 
         (Value::Record(mut a_fields), Value::Record(mut b_fields)) => {
             let a_ctor =
@@ -2909,18 +2960,17 @@ fn match_pat_list(
     let mut out = std::collections::HashMap::new();
     let mut cur = v.clone();
     for p in ps.iter() {
-        let cur_forced = force_value(g, cur)?;
-        let Value::ListCons(h, t) = cur_forced else {
+        let Some((h, t)) = list_uncons(g, cur)? else {
             return Ok(None);
         };
         let Some(b) = match_pat(g, env, p, &h)? else {
             return Ok(None);
         };
         out.extend(b);
-        cur = *t;
+        cur = t;
     }
     let cur = force_value(g, cur)?;
-    if matches!(cur, Value::ListNil) {
+    if matches!(cur, Value::ListNil) || matches!(&cur, Value::String(s) if s.is_empty()) {
         Ok(Some(out))
     } else {
         Ok(None)
@@ -2934,8 +2984,7 @@ fn match_pat_cons(
     tl: &IrPattern,
     v: &Value,
 ) -> Result<Option<std::collections::HashMap<String, Value>>> {
-    let v = force_and_auto_apply(g, v.clone())?;
-    let Value::ListCons(h, t) = v else {
+    let Some((h, t)) = list_uncons(g, force_and_auto_apply(g, v.clone())?)? else {
         return Ok(None);
     };
     let mut out = std::collections::HashMap::new();
@@ -3130,6 +3179,10 @@ mod show_roundtrip_tests {
         Value::Integer(int_from_i64(n))
     }
 
+    fn chars(s: &str) -> Value {
+        string_to_char_list(s)
+    }
+
     #[test]
     fn show_value_str_roundtrips_through_parser_for_literals() {
         let g0 = Globals::from_module(&IrModule { items: vec![] });
@@ -3156,5 +3209,14 @@ mod show_roundtrip_tests {
                 eval_show_str(&s1).unwrap_or_else(|e| panic!("failed to roundtrip: {s1}: {e}"));
             assert_eq!(s1, s2);
         }
+    }
+
+    #[test]
+    fn eq_values_accepts_string_charlist_interop() {
+        let g0 = Globals::from_module(&IrModule { items: vec![] });
+
+        assert!(eq_values(&g0, Value::String("ab".to_string()), chars("ab")).unwrap());
+        assert!(eq_values(&g0, chars("ab"), Value::String("ab".to_string())).unwrap());
+        assert!(eq_values(&g0, Value::String(String::new()), Value::ListNil).unwrap());
     }
 }

--- a/src/kir1.rs
+++ b/src/kir1.rs
@@ -69,7 +69,7 @@ pub fn encode_ksif_module(module: &KsifModule) -> Vec<u8> {
         },
     ];
 
-    let file_len = (interface_off + interface_payload.len() as u64) as u64;
+    let file_len = interface_off + interface_payload.len() as u64;
     let mut out = Vec::with_capacity(file_len as usize);
 
     out.extend_from_slice(&MAGIC);

--- a/src/parser_impl.rs
+++ b/src/parser_impl.rs
@@ -2737,15 +2737,7 @@ fn parse_atom(ts: &mut TokenStream) -> Result<ast::Expr> {
             _ => unreachable!(),
         },
         Some(TokenKind::String(_)) => match ts.bump() {
-            Some(TokenKind::String(s)) => {
-                // Desugar string literal expressions into list-of-char expressions.
-                // This aligns with Haskell surface semantics where String ~ [Char].
-                let es = s
-                    .chars()
-                    .map(|ch| ast::Expr::dummy(ast::ExprKind::Char(ch)))
-                    .collect::<Vec<_>>();
-                Ok(expr_from(ts, start, ast::ExprKind::List(es)))
-            }
+            Some(TokenKind::String(s)) => Ok(expr_from(ts, start, ast::ExprKind::String(s))),
             _ => unreachable!(),
         },
         Some(TokenKind::Char(_)) => match ts.bump() {

--- a/tests/io_apis.rs
+++ b/tests/io_apis.rs
@@ -30,6 +30,47 @@ fn test_readfile_writefile_api() {
 }
 
 #[test]
+fn test_readfile_two_qualified_imports_regression() {
+    let dir = std::env::temp_dir().join(format!(
+        "kscr_test_readfile_two_qualified_imports_regression_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+
+    let program = dir.join("Program.ks");
+    let program_src = "module Main where\n  import Prelude\n  import qualified Foo as Foo\n  import qualified Bar as Bar\n\n  main = do\n    putStrLn Foo.hello\n    putStrLn Bar.msg\n";
+    std::fs::write(&program, program_src).expect("write Program.ks");
+
+    let main = dir.join("Main.ks");
+    std::fs::write(
+        &main,
+        "module Main where\n  import Prelude\n\n  countChars = \\xs -> case xs of\n    [] -> 0\n    _ : rest -> 1 + countChars rest\n\n  main = do\n    content <- readFile \"Program.ks\"\n    print (show (countChars content))\n",
+    )
+    .expect("write Main.ks");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_kscr"))
+        .args(["run", "Main.ks"])
+        .current_dir(&dir)
+        .output()
+        .expect("run kscr");
+
+    assert!(
+        out.status.success(),
+        "expected success, got status {:?}, stdout={}, stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let expected = format!("\"{}\"", program_src.chars().count());
+    assert_eq!(stdout.trim(), expected);
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn test_exitwith_api() {
     let out = Command::new(env!("CARGO_BIN_EXE_kscr"))
         .args(["run", "tests/test_exitwith.ks"])


### PR DESCRIPTION
## Summary
- keep string literals and readFile results as runtime String values instead of eagerly desugaring to [Char]
- reduce recursive environment cloning by sharing closure environments with Rc
- preserve String/[Char] interop in list matching and equality, and add regressions for the readFile overflow path

## Validation
- cargo test
- cargo fmt -- --check
- cargo clippy --all-features -- -D warnings

Closes #96