### PR TITLE
Parse applied types in infix constructor declarations

### DIFF
--- a/crates/kscr_lsp/src/backend_semantic_tokens.rs
+++ b/crates/kscr_lsp/src/backend_semantic_tokens.rs
@@ -788,6 +788,7 @@ mod tests {
             ("prefix", "data Pair a b = (:*:) a b"),
             ("infix", "data Pair a b = a :*: b"),
             ("infix_uppercase", "data Pair b = A :*: b"),
+            ("infix_applied", "data Pair a b = Maybe a :*: Either a b"),
         ] {
             let uri = tower_lsp::lsp_types::Url::parse(&format!(
                 "file:///semantic_tokens_{name}_ctor_decl.ks"

--- a/docs/LanguageBNF.md
+++ b/docs/LanguageBNF.md
@@ -184,13 +184,18 @@ deriving_clause ::= 'deriving' <identifier> | 'deriving' '(' <identifier> {',' <
 type_name ::= <identifier>
 type_vars ::= <identifier> {<identifier>}
 ctor_list ::= ctor {'|' ctor}
-ctor ::= <identifier> ctor_args
+ctor ::= prefix_ctor | infix_ctor
+prefix_ctor ::= (<identifier> | '(' <constructor_operator> ')') ctor_args
+infix_ctor ::= type_app <constructor_operator> type_app
+constructor_operator ::= <operator beginning with ':'>
 ctor_args ::= /* empty */ | type_atom {type_atom}
+type_app ::= type_atom {type_atom}
 type_atom ::= <identifier> | '(' type ')'
 
 # Example:
 # data Maybe a = Nothing | Just a
 # data Either a b = Left a | Right b
+# data Pair a b = Maybe a :*: Either a b
 
 ---
 

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -848,27 +848,41 @@ fn parser_golden_decl() {
 
 #[test]
 fn parser_accepts_prefix_and_infix_symbolic_data_constructors() {
+    use crate::ast::Type;
+
+    fn var(name: &str) -> Type {
+        Type::Var(name.to_string())
+    }
+
+    fn app(name: &str, args: Vec<Type>) -> Type {
+        Type::App {
+            head: Box::new(var(name)),
+            args,
+        }
+    }
+
     for (decl, expected_args) in [
+        ("data Pair a b = (:*:) a b", vec![var("a"), var("b")]),
+        ("data Pair a b = a :*: b", vec![var("a"), var("b")]),
+        ("data Pair b = A :*: b", vec![var("A"), var("b")]),
         (
-            "data Pair a b = (:*:) a b",
+            "data Pair a b = Maybe a :*: b",
+            vec![app("Maybe", vec![var("a")]), var("b")],
+        ),
+        (
+            "data Pair a b = a :*: Maybe b",
+            vec![var("a"), app("Maybe", vec![var("b")])],
+        ),
+        (
+            "data Pair e a b = Either e a :*: Maybe b",
             vec![
-                crate::ast::Type::Var("a".to_string()),
-                crate::ast::Type::Var("b".to_string()),
+                app("Either", vec![var("e"), var("a")]),
+                app("Maybe", vec![var("b")]),
             ],
         ),
         (
-            "data Pair a b = a :*: b",
-            vec![
-                crate::ast::Type::Var("a".to_string()),
-                crate::ast::Type::Var("b".to_string()),
-            ],
-        ),
-        (
-            "data Pair b = A :*: b",
-            vec![
-                crate::ast::Type::Var("A".to_string()),
-                crate::ast::Type::Var("b".to_string()),
-            ],
+            "data Pair a b c = (a -> b) :*: c",
+            vec![Type::Func(Box::new(var("a")), Box::new(var("b"))), var("c")],
         ),
     ] {
         let module = crate::parser::parse_module(decl).unwrap_or_else(|err| {
@@ -885,6 +899,76 @@ fn parser_accepts_prefix_and_infix_symbolic_data_constructors() {
             "unexpected ctor arguments for `{decl}`"
         );
     }
+
+    let decl = "data Pair a b = Maybe a :*: Either a b | Prefix (Maybe a) [b] deriving (Eq, Show)";
+    let module = crate::parser::parse_module(decl).unwrap();
+    let crate::ast::Item::DataDecl(data) = &module.items[0] else {
+        panic!("expected data declaration for `{decl}`");
+    };
+    assert_eq!(data.ctors.len(), 2);
+    assert_eq!(data.ctors[0].name, ":*:");
+    assert_eq!(
+        data.ctors[0].args,
+        vec![
+            app("Maybe", vec![var("a")]),
+            app("Either", vec![var("a"), var("b")]),
+        ]
+    );
+    assert_eq!(data.ctors[1].name, "Prefix");
+    assert_eq!(
+        data.ctors[1].args,
+        vec![app("Maybe", vec![var("a")]), Type::List(Box::new(var("b")))]
+    );
+    assert_eq!(data.deriving, vec!["Eq", "Show"]);
+
+    for (invalid, reason) in [
+        (
+            "data Bad a b c = a -> b :*: c",
+            "unparenthesized function type must not be accepted as an infix constructor operand",
+        ),
+        (
+            "data Bad a = a :*: deriving Show",
+            "deriving must not be consumed as a missing infix constructor operand",
+        ),
+    ] {
+        assert!(crate::parser::parse_module(invalid).is_err(), "{reason}");
+    }
+}
+
+#[test]
+fn typecheck_infix_constructor_applied_operands_preserve_data_params() {
+    let declarations = concat!(
+        "data MMaybe a = MNothing | MJust a\n",
+        "data EEither a b = L a | R b\n",
+        "data Pair a b = MMaybe a :*: EEither a b\n",
+    );
+
+    let valid = format!(
+        "{declarations}data IntPair = IntPair (Pair Integer Char)\n\
+         value = IntPair ((:*:) (MJust 1) (L 1))\n"
+    );
+    let module = crate::parser::parse_module(&valid).unwrap();
+    crate::types::typecheck(module).unwrap();
+
+    let invalid_a = format!(
+        "{declarations}data BoolPair = BoolPair (Pair Bool Char)\n\
+         value = BoolPair ((:*:) (MJust 1) (L 1))\n"
+    );
+    let module = crate::parser::parse_module(&invalid_a).unwrap();
+    assert!(
+        crate::types::typecheck(module).is_err(),
+        "the first constructor field must constrain the first result parameter"
+    );
+
+    let invalid_b = format!(
+        "{declarations}data CharPair = CharPair (Pair Bool Char)\n\
+         value = CharPair ((:*:) MNothing (R 1))\n"
+    );
+    let module = crate::parser::parse_module(&invalid_b).unwrap();
+    assert!(
+        crate::types::typecheck(module).is_err(),
+        "the second constructor field must constrain the second result parameter"
+    );
 }
 
 #[test]

--- a/src/parser_impl.rs
+++ b/src/parser_impl.rs
@@ -651,7 +651,7 @@ fn parse_algebraic_decl(
             Some(ctor)
         } else {
             (ts.i, ts.last_span_end) = save;
-            let lhs = parse_type_atom(ts, Stop::LineEnd, is_type_alias_end)?;
+            let lhs = parse_algebraic_ctor_operand(ts)?;
             let Some(TokenKind::Operator(op)) = ts.peek_kind() else {
                 return Err(ts.err_here("expected constructor name"));
             };
@@ -661,7 +661,7 @@ fn parse_algebraic_decl(
             let op = op.clone();
             let ctor_start = ts.peek_span().map(|s| s.start).unwrap_or(ts.last_span_end);
             ts.bump();
-            let rhs = parse_type_atom(ts, Stop::LineEnd, is_type_alias_end)?;
+            let rhs = parse_algebraic_ctor_operand(ts)?;
             let ctor_end = ts.last_span_end;
             Some(ast::DataCtor {
                 doc: ctor_doc_buf.take(),
@@ -2571,6 +2571,20 @@ fn is_type_alias_end(kind: Option<&TokenKind>, _stop: Stop) -> bool {
     type_expr::is_type_alias_end_public(kind, Stop::LineEnd)
 }
 
+fn is_algebraic_ctor_operand_end(kind: Option<&TokenKind>, _stop: Stop) -> bool {
+    matches!(
+        kind,
+        None | Some(TokenKind::Newline) | Some(TokenKind::Pipe) | Some(TokenKind::Dedent)
+    ) || matches!(kind, Some(TokenKind::Ident(name)) if name == "deriving")
+}
+
+fn parse_algebraic_ctor_operand(ts: &mut TokenStream) -> Result<ast::Type> {
+    if is_algebraic_ctor_operand_end(ts.peek_kind(), Stop::LineEnd) {
+        return Err(ts.err_here("expected type"));
+    }
+    parse_type_app(ts, Stop::LineEnd, is_algebraic_ctor_operand_end)
+}
+
 fn is_type_end(kind: Option<&TokenKind>, stop: Stop) -> bool {
     type_expr::is_type_end_in_root(kind, stop)
 }
@@ -2581,6 +2595,14 @@ fn parse_type_expr(
     end: fn(Option<&TokenKind>, Stop) -> bool,
 ) -> Result<ast::Type> {
     type_expr::parse_type_expr_in_root(ts, stop, end)
+}
+
+fn parse_type_app(
+    ts: &mut TokenStream,
+    stop: Stop,
+    end: fn(Option<&TokenKind>, Stop) -> bool,
+) -> Result<ast::Type> {
+    type_expr::parse_type_app_in_root(ts, stop, end)
 }
 
 fn parse_type_atom(

--- a/src/parser_impl/type_expr.rs
+++ b/src/parser_impl/type_expr.rs
@@ -199,6 +199,14 @@ fn parse_type_app(
     }
 }
 
+pub(crate) fn parse_type_app_in_root(
+    ts: &mut TokenStream,
+    stop: Stop,
+    end: fn(Option<&TokenKind>, Stop) -> bool,
+) -> Result<ast::Type> {
+    parse_type_app(ts, stop, end)
+}
+
 fn is_type_atom_start(kind: Option<&TokenKind>) -> bool {
     matches!(
         kind,

--- a/src/types.rs
+++ b/src/types.rs
@@ -3800,6 +3800,48 @@ fn lower_surface_type_with_params(
             .get(name)
             .map(|v| Ty::Var(*v))
             .unwrap_or_else(|| Ty::Con(name.clone())),
+        Type::List(t) => Ty::List(Box::new(lower_surface_type_with_params(
+            cx, t, holes, params,
+        ))),
+        Type::Tuple(ts) => Ty::Tuple(
+            ts.iter()
+                .map(|t| lower_surface_type_with_params(cx, t, holes, params))
+                .collect(),
+        ),
+        Type::Record(fields) => Ty::Record(
+            fields
+                .iter()
+                .map(|(name, t)| {
+                    (
+                        name.clone(),
+                        lower_surface_type_with_params(cx, t, holes, params),
+                    )
+                })
+                .collect(),
+        ),
+        Type::RecordOpen(fields, rest) => Ty::RecordOpen(
+            fields
+                .iter()
+                .map(|(name, t)| {
+                    (
+                        name.clone(),
+                        lower_surface_type_with_params(cx, t, holes, params),
+                    )
+                })
+                .collect(),
+            Box::new(lower_surface_type_with_params(cx, rest, holes, params)),
+        ),
+        Type::Func(a, b) => Ty::Func(
+            Box::new(lower_surface_type_with_params(cx, a, holes, params)),
+            Box::new(lower_surface_type_with_params(cx, b, holes, params)),
+        ),
+        Type::App { head, args } => Ty::App {
+            head: Box::new(lower_surface_type_with_params(cx, head, holes, params)),
+            args: args
+                .iter()
+                .map(|t| lower_surface_type_with_params(cx, t, holes, params))
+                .collect(),
+        },
         other => lower_surface_type(cx, other, holes),
     }
 }


### PR DESCRIPTION
## Summary

- parse type applications on both sides of infix data constructors while keeping prefix constructor fields atomic
- preserve declared data-parameter identity recursively inside constructor field types
- reject a missing infix operand before deriving, document the grammar, and extend semantic-token coverage

## Root cause

The infix fallback parsed each operand as a single type atom, so declarations such as Maybe a :*: Either a b failed. Once those applications were parsed, constructor-scheme lowering only mapped top-level type variables, which disconnected nested a and b variables from the Pair a b result. The fix reuses type-application parsing at the infix boundary and recursively lowers composite field types with the declared parameter map.

## Validation

- cargo +1.97.0 test -- --test-threads=1
- cargo +1.97.0 test --lib overlap_diagnostics_tests -- --test-threads=16
- cargo +1.97.0 fmt -- --check
- cargo +1.97.0 clippy --all-features -- -D warnings
- codex review --uncommitted